### PR TITLE
_toc.yml update

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -10,29 +10,39 @@ parts:
     - file: notebooks/COS/DataDl/DataDl.ipynb
     - file: notebooks/COS/ViewData/ViewData.ipynb
     - file: notebooks/COS/AsnFile/AsnFile.ipynb
-    - file: notebooks/COS/CalCOS/CalCOS.ipynb
-    - file: notebooks/COS/SplitTag/SplitTag.ipynb
-    - file: notebooks/COS/DayNight/DayNight.ipynb
-    - file: notebooks/COS/LSF/LSF.ipynb
-    - file: notebooks/COS/Extract/Extract.ipynb
+# Notebook excluded from build until build failures are fixed (See SPB-1258)
+#    - file: notebooks/COS/CalCOS/CalCOS.ipynb
+# Notebook excluded from build until build failures are fixed (See SPB-1262)
+#    - file: notebooks/COS/SplitTag/SplitTag.ipynb
+# Notebook excluded from build until build failures are fixed (See SPB-1259)
+#    - file: notebooks/COS/DayNight/DayNight.ipynb
+# Notebook excluded from build until build failures are fixed (See SPB-1260)
+#    - file: notebooks/COS/LSF/LSF.ipynb
+# Notebook excluded from build until build failures are fixed (See SPB-1261)
+#    - file: notebooks/COS/Extract/Extract.ipynb
     - file: notebooks/COS/example_notebook/example_notebook.ipynb
   - caption: DrizzlePac
     chapters:
       - file: notebooks/DrizzlePac/README.md
-      - file: notebooks/DrizzlePac/Initialization/Initialization.ipynb
-      - file: notebooks/DrizzlePac/align_to_catalogs/align_to_catalogs.ipynb
+# Notebook excluded from build until build failures are fixed (See SPB-1263)
+#      - file: notebooks/DrizzlePac/Initialization/Initialization.ipynb
+# Notebook excluded from build until build failures are fixed (See SPB-1264)
+#      - file: notebooks/DrizzlePac/align_to_catalogs/align_to_catalogs.ipynb
 # Notebook excluded from build until build failures are fixed (See SPB-1168)
 #      - file: notebooks/DrizzlePac/align_mosaics/align_mosaics.ipynb
       - file: notebooks/DrizzlePac/align_multiple_visits/align_multiple_visits.ipynb
       - file: notebooks/DrizzlePac/align_sparse_fields/align_sparse_fields.ipynb
-      - file: notebooks/DrizzlePac/drizzle_wfpc2/drizzle_wfpc2.ipynb
+# Notebook excluded from build until build failures are fixed (See SPB-1265)
+#      - file: notebooks/DrizzlePac/drizzle_wfpc2/drizzle_wfpc2.ipynb
+# Notebook excluded from build until build failures are fixed (See SPB-1266)
       - file: notebooks/DrizzlePac/mask_satellite/mask_satellite.ipynb
       - file: notebooks/DrizzlePac/optimize_image_sampling/optimize_image_sampling.ipynb
 # Notebook excluded from build until build failures are fixed (See SPB-1160)
 #      - file: notebooks/DrizzlePac/sky_matching/sky_matching.ipynb
-# Notebook excluded from build until build failures are fixed (See SPB-1153)
+# Notebook excluded from build until build failures are fixed (See SPB-1153, SPB-1269)
 #      - file: notebooks/DrizzlePac/use_ds9_regions_in_tweakreg/use_ds9_regions_in_tweakreg.ipynb
-      - file: notebooks/DrizzlePac/using_updated_astrometry_solutions/using_updated_astrometry_solutions.ipynb
+# Notebook excluded from build until build failures are fixed (See SPB-1267)
+#      - file: notebooks/DrizzlePac/using_updated_astrometry_solutions/using_updated_astrometry_solutions.ipynb
   - caption: NICMOS
     chapters:
     - file: notebooks/NICMOS/nicmos_unit_conversion/nicmos_unit_conversion.ipynb


### PR DESCRIPTION
Updated _toc.yml to temporarily exclude the 10 additional notebooks that failed automated validation tests ran as part of PR #9  (see ticket [SPB-1268](https://jira.stsci.edu/browse/SPB-1268)) from HTML build until issues can be resolved.